### PR TITLE
Add architectures stanza

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -13,6 +13,11 @@ description: |
 grade: stable
 confinement: strict
 
+architectures:
+  - build-on: amd64
+  - build-on: i386
+  - build-on: armhf
+
 parts:
   love0.10.2:
     source: https://bitbucket.org/rude/love/downloads/love_0.10.2ppa1_amd64.deb
@@ -21,7 +26,6 @@ parts:
       - on amd64: https://bitbucket.org/rude/love/downloads/love_0.10.2ppa1_amd64.deb
       - on i386: https://bitbucket.org/rude/love/downloads/love_0.10.2ppa1_i386.deb
       - on armhf: https://bitbucket.org/rude/love/downloads/love_0.10.2ppa1_armhf.deb
-      - on arm64: fail
     # Suitable stage-packages for LOVE 0.9.x and 0.10.x
     stage-packages:
       - libdevil1c2
@@ -44,7 +48,6 @@ parts:
       - on amd64: https://bitbucket.org/rude/love/downloads/liblove0_0.10.2ppa1_amd64.deb
       - on i386: https://bitbucket.org/rude/love/downloads/liblove0_0.10.2ppa1_i386.deb
       - on armhf: https://bitbucket.org/rude/love/downloads/liblove0_0.10.2ppa1_armhf.deb
-      - on arm64: fail
     plugin: dump
     after:
       - love0.10.2


### PR DESCRIPTION
Adding the architectures stanza which means we don't waste time building on unsupported architectures. See [this thread](https://forum.snapcraft.io/t/architectures/4972) for more details.